### PR TITLE
Provide friendlier error messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ bot.on( 'message', msg => {
 		} )
 		.then( () => followBlog( msg.chat.id, 'group', url ) )
 		.then( () => bot.sendMessage( msg.chat.id, 'Following!' ) )
-		.catch( error => handleError( error, msg.chat.id, urlfix/friendly-error-messages ) );
+		.catch( error => handleError( error, msg.chat.id, url ) );
 } );
 
 bot.on( 'channel_post', ( msg ) => {

--- a/index.js
+++ b/index.js
@@ -53,6 +53,16 @@ Here's how you can use this bot:
 * Voilà!  Your channel or group will now receive a notification everytime a new post is created
 `;
 
+function handleError( error, id, url ) {
+	debug( error.message );
+
+	if ( error.message.includes( 'E11000 duplicate key' )) {
+		return bot.sendMessage( id, `You seem to already be following ${url}` );
+	}
+
+	return bot.sendMessage( id, `Sorry - there was a problem following ${url}` );
+}
+
 bot.on( 'message', msg => {
 	debug( 'received', msg );
 
@@ -79,11 +89,11 @@ bot.on( 'message', msg => {
 		} )
 		.then( () => followBlog( msg.chat.id, 'group', url ) )
 		.then( () => bot.sendMessage( msg.chat.id, 'Following!' ) )
-		.catch( error => bot.sendMessage( msg.chat.id, 'Error: ' + error.message ) );
-
+		.catch( error => handleError( error, msg.chat.id, urlfix/friendly-error-messages ) );
 } );
 
 bot.on( 'channel_post', ( msg ) => {
+	debug( 'received', msg );
 	// ignore messages from groups
 	if ( msg.chat.type !== 'channel' ) {
 		return;
@@ -98,9 +108,9 @@ bot.on( 'channel_post', ( msg ) => {
 	debug( 'Following ' + url );
 
 	// only admins can post to channel
-	followBlog( msg.chat.id, 'channel', url ).then( () => {
-		bot.sendMessage( msg.chat.id, 'Following!' );
-	} ).catch( error => bot.sendMessage( msg.chat.id, 'Error: ' + error.message ) );
+	followBlog( msg.chat.id, 'channel', url )
+		.then( () => bot.sendMessage( msg.chat.id, 'Following!' ) )
+		.catch( error => handleError( error, msg.chat.id, url ) );
 } );
 
 require( 'http' ).createServer( ( request, response ) => {

--- a/index.js
+++ b/index.js
@@ -56,11 +56,11 @@ Here's how you can use this bot:
 function handleError( error, id, url ) {
 	debug( error.message );
 
-	if ( error.message.includes( 'E11000 duplicate key' )) {
+	if ( error.name === 'MongoError' && error.code === 11000 ) {
 		return bot.sendMessage( id, `You seem to already be following ${url}` );
 	}
 
-	return bot.sendMessage( id, `Sorry - there was a problem following ${url}` );
+	return bot.sendMessage( id, error.message );
 }
 
 bot.on( 'message', msg => {

--- a/index.js
+++ b/index.js
@@ -84,8 +84,9 @@ bot.on( 'message', msg => {
 	bot.getChatAdministrators( msg.chat.id )
 	.then( administrators => {
 		if ( administrators.filter( admin => admin.user.username === msg.from.username ).length === 0 ) {
-				return Promise.reject( new Error( 'You need to be an administrator of the channel to do that' ) );
+			return Promise.reject( new Error( 'You need to be an administrator of the channel to do that' ) );
 		}
+		return Promise.resolve();
 	} )
 	.then( () => followBlog( msg.chat.id, 'group', url ) )
 	.then( () => bot.sendMessage( msg.chat.id, 'Following!' ) )

--- a/index.js
+++ b/index.js
@@ -82,14 +82,14 @@ bot.on( 'message', msg => {
 	}
 
 	bot.getChatAdministrators( msg.chat.id )
-	.then( administrators => {
-		if ( administrators.filter( admin => admin.user.username === msg.from.username ).length === 0 ) {
-			return Promise.reject( new Error( 'You need to be an administrator of the channel to do that' ) );
-		}
-	} )
-	.then( () => followBlog( msg.chat.id, 'group', url ) )
-	.then( () => bot.sendMessage( msg.chat.id, 'Following!' ) )
-	.catch( error => handleError( error, msg.chat.id, url ) );
+		.then( administrators => {
+			if ( administrators.filter( admin => admin.user.username === msg.from.username ).length === 0 ) {
+				return Promise.reject( new Error( 'You need to be an administrator of the channel to do that' ) );
+			}
+		} )
+		.then( () => followBlog( msg.chat.id, 'group', url ) )
+		.then( () => bot.sendMessage( msg.chat.id, 'Following!' ) )
+		.catch( error => handleError( error, msg.chat.id, url ) );
 } );
 
 bot.on( 'channel_post', ( msg ) => {

--- a/index.js
+++ b/index.js
@@ -85,11 +85,11 @@ bot.on( 'message', msg => {
 	.then( administrators => {
 		if ( administrators.filter( admin => admin.user.username === msg.from.username ).length === 0 ) {
 				return Promise.reject( new Error( 'You need to be an administrator of the channel to do that' ) );
-			}
-		} )
-		.then( () => followBlog( msg.chat.id, 'group', url ) )
-		.then( () => bot.sendMessage( msg.chat.id, 'Following!' ) )
-		.catch( error => handleError( error, msg.chat.id, url ) );
+		}
+	} )
+	.then( () => followBlog( msg.chat.id, 'group', url ) )
+	.then( () => bot.sendMessage( msg.chat.id, 'Following!' ) )
+	.catch( error => handleError( error, msg.chat.id, url ) );
 } );
 
 bot.on( 'channel_post', ( msg ) => {

--- a/index.js
+++ b/index.js
@@ -86,7 +86,6 @@ bot.on( 'message', msg => {
 		if ( administrators.filter( admin => admin.user.username === msg.from.username ).length === 0 ) {
 			return Promise.reject( new Error( 'You need to be an administrator of the channel to do that' ) );
 		}
-		return Promise.resolve();
 	} )
 	.then( () => followBlog( msg.chat.id, 'group', url ) )
 	.then( () => bot.sendMessage( msg.chat.id, 'Following!' ) )

--- a/xmpp.js
+++ b/xmpp.js
@@ -33,9 +33,9 @@ client.on('online', jid => {
 } );
 
 client.on('stanza', stanza => {
-	console.log('>> Stanza', stanza.toString())
+	debug( 'received stanza ' + stanza.toString() );
 	if ( stanza.is( 'message' ) ) {
-		debug( 'got message ' + stanza.toString() );
+		debug( 'stanza is message ' );
 		const body = stanza.getChild( 'body' );
 
 		if ( body ) {


### PR DESCRIPTION
This attempts to provide more user friendly error messages when the attempt to store the association between a site and telegram channel/group fails.

This addresses issue #2.
