### PR TITLE
Add/handle sub xmpp response to determine whether subscription was successful

### DIFF
--- a/cleanUrl.js
+++ b/cleanUrl.js
@@ -1,0 +1,6 @@
+function cleanUrl( url ) {
+	const newUrl = url.replace(/∕/g, '/');
+	return newUrl.endsWith( '/' ) ? newUrl : newUrl + '/';
+}
+
+module.exports = cleanUrl;

--- a/database.js
+++ b/database.js
@@ -1,17 +1,12 @@
 const mongodb = require("mongodb");
 const MongoClient = mongodb.MongoClient;
 const debug = require( 'debug' )( 'wp-telegram-bot:database' );
+const cleanUrl = require( './cleanUrl' );
 
 require( 'dotenv' ).load();
 
 const DB_URL = process.env.MONGODB_URI || 'mongodb://127.0.0.1:27017/wp-telegram-bot';
 const dbP = MongoClient.connect( DB_URL );
-
-function normalizeBlogPath( blogPath ) {
-	const cleanPath = blogPath.replace(/∕/g, '/');
-
-	return cleanPath.endsWith( '/' ) ? cleanPath : cleanPath + '/';
-}
 
 dbP.then( db => {
 	debug( 'Connected to ' + DB_URL );
@@ -20,11 +15,11 @@ dbP.then( db => {
 } );
 
 function followBlog( chatId, blogPath, chatType ) {
-	return dbP.then( db => db.collection( 'blogChats' ).insert( { chatId, chatType, blogPath: normalizeBlogPath( blogPath ), createdDate: new Date() } ) );
+	return dbP.then( db => db.collection( 'blogChats' ).insert( { chatId, chatType, blogPath: cleanUrl( blogPath ), createdDate: new Date() } ) );
 }
 
 function unfollowBlog( chatId, blogPath ) {
-	return dbP.then( db => db.collection( 'blogChats' ).remove( { chatId, blogPath: normalizeBlogPath( blogPath ) }, { justOne: true } ) );
+	return dbP.then( db => db.collection( 'blogChats' ).remove( { chatId, blogPath: cleanUrl( blogPath ) }, { justOne: true } ) );
 }
 
 function getChatsByBlogHost( blogPath ) {


### PR DESCRIPTION
Currently, the XMPP subscription response is ignored.

This PR changes the processing of channel and group `follow` commands to use the XMPP response.

This means that an attempt to subscribe to an unknown blog will return a message to the user and so resolves issue #5

Also, the url in the subscription response will be used in case the primary domain is different to the one sent via telegram so resolves issue #6.

Note that matching XMPP responses to the original XMPP request is not always going to perfect.  If many subscription requests are sent at the same time and responses are not returned in the expected order then it is possible that the wrong handler will be called, blog <-> telegram group/channel will be created incorrectly and the user may see an unexpected subscription.