### PR TITLE
Match xmpp sub request to response

### DIFF
--- a/database.js
+++ b/database.js
@@ -20,11 +20,13 @@ dbP.then( db => {
 } );
 
 function followBlog( chatId, blogPath, chatType ) {
-	return dbP.then( db => db.collection( 'blogChats' ).insert( { chatId, chatType, blogPath: normalizeBlogPath( blogPath ), createdDate: new Date() } ) );
+	debug( `adding document for chat ${chatId}, blogPath ${blogPath} and chatType ${chatType}` );
+	return dbP.then( db => db.collection( 'blogChats' ).insert( { chatId: parseInt( chatId ), chatType, blogPath: normalizeBlogPath( blogPath ), createdDate: new Date() } ) );
 }
 
 function unfollowBlog( chatId, blogPath ) {
-	return dbP.then( db => db.collection( 'blogChats' ).remove( { chatId, blogPath: normalizeBlogPath( blogPath ) }, { justOne: true } ) );
+	debug( `removing documents for chat ${chatId} and blogPath ${blogPath}` );
+	return dbP.then( db => db.collection( 'blogChats' ).remove( { chatId: parseInt( chatId ), blogPath: normalizeBlogPath( blogPath ) }, { justOne: true } ) );
 }
 
 function getChatsByBlogHost( blogPath ) {

--- a/database.js
+++ b/database.js
@@ -21,12 +21,23 @@ dbP.then( db => {
 
 function followBlog( chatId, blogPath, chatType ) {
 	debug( `adding document for chat ${chatId}, blogPath ${blogPath} and chatType ${chatType}` );
-	return dbP.then( db => db.collection( 'blogChats' ).insert( { chatId: parseInt( chatId ), chatType, blogPath: normalizeBlogPath( blogPath ), createdDate: new Date() } ) );
+	const document = {
+		chatId: parseInt( chatId ),
+		chatType,
+		blogPath: normalizeBlogPath( blogPath ),
+		createdDate: new Date()
+	};
+	return dbP
+		.then( db => db.collection( 'blogChats' ).insert( document ) );
 }
 
 function unfollowBlog( chatId, blogPath ) {
 	debug( `removing documents for chat ${chatId} and blogPath ${blogPath}` );
-	return dbP.then( db => db.collection( 'blogChats' ).remove( { chatId: parseInt( chatId ), blogPath: normalizeBlogPath( blogPath ) }, { justOne: true } ) );
+	const criteria = { chatId: parseInt( chatId ), blogPath: normalizeBlogPath( blogPath ) };
+	const limit = { justOne: true };
+	return dbP
+		.then( db => db.collection( 'blogChats' ).remove( criteria, limit ) )
+		.then( response => response.result && response.result.n );
 }
 
 function getChatsByBlogHost( blogPath ) {

--- a/index.js
+++ b/index.js
@@ -16,6 +16,13 @@ const bot = new TelegramBot( token, { polling: true } );
 
 function newPostForBlog( blogPath, postUrl ) {
 	db.getChatsByBlogHost( blogPath ).then( chats => {
+		// If we don't have any telegram channels/groups for that blog
+		// anymore, remove subscription on xmpp as well:
+		if ( chats.length === 0 ) {
+			xmpp.subscribe( blogPath );
+			return;
+		}
+		
 		chats.forEach( chat => bot.sendMessage( chat.chatId, postUrl ) );
 	} );
 }

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ function processCommand( id, command ) {
 		// we do not send a bot response yet:
 		// the response to xmpp sub command will trigger the response
 		return Promise.resolve()
-			.then( () => xmpp.subscribe( blogPath( blogUrl ), chatId ) );
+			.then( () => xmpp.subscribe( blogPath( command.blog ), id ) );
 	}
 	if ( command.method === 'unfollow' ) {
 		// we do not send an xmpp unsub command yet:

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function newPostForBlog( blogPath, postUrl ) {
 		// If we don't have any telegram channels/groups for that blog
 		// anymore, remove subscription on xmpp as well:
 		if ( chats.length === 0 ) {
-			xmpp.subscribe( blogPath );
+			xmpp.unsubscribe( blogPath );
 			return;
 		}
 		

--- a/index.js
+++ b/index.js
@@ -81,6 +81,14 @@ function handleError( error, id, url ) {
 	return bot.sendMessage( id, error.message );
 }
 
+function sendUnfollowAcknowledgement( id, blog, count ) {
+	if ( count === 0) {
+		bot.sendMessage( id, `It seems you were not following ${blog}` );
+	} else {
+		bot.sendMessage( id, `No longer following ${blog}` );
+	}
+}
+
 function processCommand( id, command ) {
 	if ( command.method === 'follow' ) {
 		// we do not send a bot response yet:
@@ -93,7 +101,7 @@ function processCommand( id, command ) {
 		// other channels may have a subscription to this same blog.
 		return Promise.resolve()
 			.then( () => db.unfollowBlog( id, blogPath( command.blog ) ) )
-			.then( () => bot.sendMessage( id, `No longer following ${command.blog}` ) );
+			.then( ( result ) => sendUnfollowAcknowledgement( id, command.blog, result ) );
 	}
 	return Promise.resolve();
 }

--- a/xmpp.js
+++ b/xmpp.js
@@ -47,8 +47,10 @@ function handleBotReply( messages ) {
 		subscriptionMessage = subscriptionMessageParts[1].trim();
 	}
 
-	debug( `Response for subscription to ${blog} in channel ${channelId} was ${subscriptionMessage}` );
-	commandResponseCallback( channelId, blog, subscriptionMessage );
+	if ( channelId && blog && subscriptionMessage ) {
+		debug( `Response for subscription to ${blog} in channel ${channelId} was ${subscriptionMessage}` );
+		commandResponseCallback( channelId, blog, subscriptionMessage );
+	}
 }
 
 client.on('stanza', stanza => {


### PR DESCRIPTION
This is an alternative implementation of #12 

In order to accurately match sub requests to sub responses, an additional sub request is added to ensure the telegram channel id is included in the xmpp response.

This ensures the xmpp response can be processed without storing any external state to recall the intended channel id.

I've also added an 'unfollow' command - note that this does not send an xmpp unsubscribe command because there may be other channels subscribing to the same blog. Instead, we can cleanup unnecessary subscriptions when a new post notification is received and there are no channels associated with that subscription.

This should solve issues #5, #6 and #9 