### PR TITLE
Add slash commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,25 @@ Users will add this bot as an admin to their channel/group and then follow WordP
 
 This also needs no special initial permissions - users will need to add this bot to their channel/group to allow it to post.
 
+## configure bot commands
+
+You configure bot commands by sending a message to BotFather:
+
+```
+/setcommands
+```
+
+BotFather will respond with 'Choose a bot to change the list of commands.' so choose your bot
+
+BotFather will respond with 'OK. Send me a list of commands for your bot ...' so respond with the following message:
+
+```
+follow - Follow a new site
+unfollow - Stop following a site
+following - List currently followed sites
+reset - Stop following all sites
+```
+
 ## local configuration
 
 Create a local `.env` file in the root of this project:

--- a/database.js
+++ b/database.js
@@ -42,12 +42,31 @@ function unfollowBlog( chatId, blogPath ) {
 
 function getChatsByBlogHost( blogPath ) {
 	const cleanPath = normalizeBlogPath( blogPath );
-	debug( 'retrieving chats by path ' + cleanPath );
+	debug( `retrieving chats by blogPath ${cleanPath}` );
 	return dbP.then( db => db.collection( 'blogChats' ).find( { blogPath: cleanPath } ).toArray() );
 }
 
+function getFollowedBlogs( chatId ) {
+	debug( `retrieving chats by chatId ${chatId}` );
+	const criteria = { chatId: parseInt( chatId ) };
+	return dbP
+		.then(
+			db => db.collection( 'blogChats' ).find( criteria ).toArray()
+		);
+}
+
+function clearFollowedBlogs( chatId ) {
+	debug( `removing all documents for chatId ${chatId}` );
+	const criteria = { chatId: parseInt( chatId ) };
+	return dbP
+		.then( db => db.collection( 'blogChats' ).remove( criteria ) )
+		.then( response => response.result && response.result.n );
+}
+
 module.exports = {
+	clearFollowedBlogs,
 	followBlog,
-	unfollowBlog,
 	getChatsByBlogHost,
+	getFollowedBlogs,
+	unfollowBlog,
 };

--- a/database.js
+++ b/database.js
@@ -7,12 +7,6 @@ require( 'dotenv' ).load();
 const DB_URL = process.env.MONGODB_URI || 'mongodb://127.0.0.1:27017/wp-telegram-bot';
 const dbP = MongoClient.connect( DB_URL );
 
-function normalizeBlogPath( blogPath ) {
-	const cleanPath = blogPath.replace(/∕/g, '/');
-
-	return cleanPath.endsWith( '/' ) ? cleanPath : cleanPath + '/';
-}
-
 dbP.then( db => {
 	debug( 'Connected to ' + DB_URL );
 
@@ -24,7 +18,7 @@ function followBlog( chatId, blogPath, chatType ) {
 	const document = {
 		chatId: parseInt( chatId ),
 		chatType,
-		blogPath: normalizeBlogPath( blogPath ),
+		blogPath: blogPath,
 		createdDate: new Date()
 	};
 	return dbP
@@ -33,7 +27,7 @@ function followBlog( chatId, blogPath, chatType ) {
 
 function unfollowBlog( chatId, blogPath ) {
 	debug( `removing documents for chat ${chatId} and blogPath ${blogPath}` );
-	const criteria = { chatId: parseInt( chatId ), blogPath: normalizeBlogPath( blogPath ) };
+	const criteria = { chatId: parseInt( chatId ), blogPath: blogPath };
 	const limit = { justOne: true };
 	return dbP
 		.then( db => db.collection( 'blogChats' ).remove( criteria, limit ) )
@@ -41,9 +35,8 @@ function unfollowBlog( chatId, blogPath ) {
 }
 
 function getChatsByBlogHost( blogPath ) {
-	const cleanPath = normalizeBlogPath( blogPath );
-	debug( `retrieving chats by blogPath ${cleanPath}` );
-	return dbP.then( db => db.collection( 'blogChats' ).find( { blogPath: cleanPath } ).toArray() );
+	debug( `retrieving chats by blogPath ${blogPath}` );
+	return dbP.then( db => db.collection( 'blogChats' ).find( { blogPath: blogPath } ).toArray() );
 }
 
 function getFollowedBlogs( chatId ) {

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function newPostForBlog( blogPath, postUrl ) {
 			xmpp.unsubscribe( blogPath );
 			return;
 		}
-		
+
 		chats.forEach( chat => bot.sendMessage( chat.chatId, postUrl ) );
 	} );
 }
@@ -46,7 +46,7 @@ function commandResponseReceived( id, blog, subscriptionMessage ) {
 xmpp.registerCommandResponseCallBack( commandResponseReceived );
 
 function blogPath( blogUrl ) {
-	const urlParts = url.parse( blogUrl );
+	const urlParts = url.parse( `http://${blogUrl}` );
 
 	if ( ! urlParts || ! urlParts.host ) {
 		throw new Error( 'Bad blog url' );
@@ -56,14 +56,13 @@ function blogPath( blogUrl ) {
 }
 
 function extractCommand( msgText ) {
-	const unfollowResult = /unfollow ((http|https):\/\/\S+)/gi.exec( msgText );
-	if ( unfollowResult && unfollowResult.length > 1) {
-		return { method: 'unfollow', blog: unfollowResult[ 1 ] };
-
+	const unfollowResult = /unfollow (https?:\/\/)?(\S+)/i.exec( msgText );
+	if ( unfollowResult && unfollowResult.length > 2) {
+		return { method: 'unfollow', blog: unfollowResult[ 2 ] };
 	}
-	const followResult = /follow ((http|https):\/\/\S+)/gi.exec( msgText );
-	if ( followResult && followResult.length > 1 ) {
-		return { method: 'follow', blog: followResult[ 1 ] };
+	const followResult = /follow (https?:\/\/)?(\S+)/i.exec( msgText );
+	if ( followResult && followResult.length > 2 ) {
+		return { method: 'follow', blog: followResult[ 2 ] };
 	}
 	return null;
 }

--- a/index.js
+++ b/index.js
@@ -14,6 +14,9 @@ const token = process.env.BOT_TOKEN;
 // Create a bot that uses 'polling' to fetch new updates
 const bot = new TelegramBot( token, { polling: true } );
 
+let botUserName = null;
+bot.getMe().then( me => botUserName = me.username );
+
 function newPostForBlog( blogPath, postUrl ) {
 	db.getChatsByBlogHost( blogPath ).then( chats => {
 		// If we don't have any telegram channels/groups for that blog
@@ -55,25 +58,45 @@ function blogPath( blogUrl ) {
 	return urlParts.host + urlParts.path;
 }
 
-function extractCommand( msgText ) {
-	const unfollowResult = /unfollow (https?:\/\/)?(\S+)/i.exec( msgText );
-	if ( unfollowResult && unfollowResult.length > 2) {
-		return { method: 'unfollow', blog: unfollowResult[ 2 ] };
+function extractUrl( text ) {
+	const result = /(https?:\/\/)?(\S+)/i.exec( text );
+	if ( result && result.length > 2) {
+		return result[2];
 	}
-	const followResult = /follow (https?:\/\/)?(\S+)/i.exec( msgText );
-	if ( followResult && followResult.length > 2 ) {
-		return { method: 'follow', blog: followResult[ 2 ] };
+	throw new Error( `${text} does not contain a valid site address` );
+}
+
+function parseCommand( text, username ) {
+	const suffix = username ? `@${username}` : '';
+	const parts = text.split( ' ' );
+	const command = parts[0];
+
+	switch ( command ) {
+	case `/start${suffix}`:
+	case `/help${suffix}`:
+		return { method: 'usage' };
+	case `/follow${suffix}`:
+		return { method: 'follow', blog: extractUrl( parts[1] ) };
+	case `/unfollow${suffix}`:
+		return { method: 'unfollow', blog: extractUrl( parts[1] ) };
+	case `/following${suffix}`:
+		return { method: 'following' };
+	case `/reset${suffix}`:
+		return { method: 'reset' };
+	default:
+		return { method: 'unknown' };
 	}
+
 	return null;
 }
 
-const usage = `Hi there!
+const usage = ( suffix ) => `Hi there!
 
 Here's how you can use this bot:
 
 * Create a channel or group
 * Add this bot as an administrator
-* Type 'follow https://yourexcellentsite.com' into the channel or group
+* Execute the '/follow${suffix}' command and then the site url
 * Voilà!  Your channel or group will now receive a notification everytime a new post is created
 `;
 
@@ -95,28 +118,58 @@ function sendUnfollowAcknowledgement( id, blog, count ) {
 	}
 }
 
-function processCommand( id, command ) {
-	if ( command.method === 'follow' ) {
+function processCommand( id, command, username ) {
+	const suffix = username ? `@${username}` : '';
+	debug( 'processing command', id, command );
+	switch( command.method ) {
+	case 'usage':
+		bot.sendMessage( id, usage( suffix ) );
+		break;
+	case 'follow':
 		// we do not send a bot response yet:
 		// the response to xmpp sub command will trigger the response
 		return Promise.resolve()
 			.then( () => xmpp.subscribe( blogPath( command.blog ), id ) );
-	}
-	if ( command.method === 'unfollow' ) {
+	case 'unfollow':
 		// we do not send an xmpp unsub command yet:
 		// other channels may have a subscription to this same blog.
 		return Promise.resolve()
 			.then( () => db.unfollowBlog( id, blogPath( command.blog ) ) )
 			.then( ( result ) => sendUnfollowAcknowledgement( id, command.blog, result ) );
+	case 'following':
+		return db.getFollowedBlogs( id )
+			.then(
+				blogs => {
+					if ( blogs.length == 0 ) {
+						bot.sendMessage( id, 'You are not following any sites' );
+					} else {
+						const blogsDescription = blogs.map( blog => blog.blogPath );
+						bot.sendMessage(
+							id,
+							`You are following:\n${blogsDescription.join("\n")}`
+						);
+					}
+				}
+			);
+	case 'reset':
+		return db.clearFollowedBlogs( id )
+			.then(
+				count => bot.sendMessage( id, `Removed ${ count } sites` )
+			);
+	default:
+		bot.sendMessage( id, "Sorry, I don't know what you mean." );
 	}
 	return Promise.resolve();
 }
 
 bot.on( 'message', msg => {
-	debug( 'received', msg );
+	debug( 'received message', msg );
 
 	if ( msg.chat.type === 'private' ) {
-		bot.sendMessage( msg.chat.id, usage );
+		const command = parseCommand( msg.text );
+		if ( command ) {
+			processCommand( msg.chat.id, command );
+		}
 		return;
 	}
 
@@ -124,7 +177,7 @@ bot.on( 'message', msg => {
 		return;
 	}
 
-	const command = extractCommand( msg.text );
+	const command = parseCommand( msg.text, botUserName );
 
 	if ( ! command ) {
 		return;
@@ -136,28 +189,25 @@ bot.on( 'message', msg => {
 				return Promise.reject( new Error( 'You need to be an administrator of the channel to do that' ) );
 			}
 		} )
-		.then( () => processCommand( msg.chat.id, command ) )
-		.catch( error => handleError( error, msg.chat.id, url ) );
+		.then( () => processCommand( msg.chat.id, command, botUserName ) )
+		.catch( error => handleError( error, msg.chat.id, command.blog ) );
 } );
 
 bot.on( 'channel_post', ( msg ) => {
 	debug( 'received', msg );
+
 	// ignore messages from groups
 	if ( msg.chat.type !== 'channel' ) {
 		return;
 	}
 
-	const command = extractCommand( msg.text );
+	const command = extractCommand( msg.text, botUserName );
 
-	if ( ! command ) {
-		return;
+	if ( command ) {
+		// only admins can post to channel
+		processCommand( msg.chat.id, command, botUserName )
+			.catch( error => handleError( error, msg.chat.id, command.blog ) );
 	}
-
-	debug( 'Following ' + url );
-
-	// only admins can post to channel
-	processCommand( msg.chat.id, command )
-		.catch( error => handleError( error, msg.chat.id, url ) );
 } );
 
 require( 'http' ).createServer( ( request, response ) => {

--- a/index.js
+++ b/index.js
@@ -201,7 +201,7 @@ bot.on( 'channel_post', ( msg ) => {
 		return;
 	}
 
-	const command = extractCommand( msg.text, botUserName );
+	const command = parseCommand( msg.text, botUserName );
 
 	if ( command ) {
 		// only admins can post to channel

--- a/xmpp.js
+++ b/xmpp.js
@@ -87,13 +87,14 @@ client.handle('authenticate', authenticate => authenticate( XMPP_USER, XMPP_PASS
 client.handle('bind', bind => bind( 'bot' ) )
 
 function sendMessage( to, text ) {
+	debug( `sending message to ${ to } : ${ text }` );
 	const message = xml('message', { to: to } , xml('body', null, text ) );
 	return client.send( message );
 }
 
 // see: https://en.support.wordpress.com/jabber/
-const subscribe = ( blogPath, id ) => sendMessage( botId, `sub ${id}.channel ${blogPath}/posts` );
-const unsubscribe = blogPath => sendMessage( botId, 'unsub ' + blogPath + '/posts' );
+const subscribe = ( subPath, id ) => sendMessage( botId, `sub ${ id }.channel ${ subPath }` );
+const unsubscribe = unsubPath => sendMessage( botId, 'unsub ' + unsubPath );
 
 const registerNewPostCallBack = callback => newPostCallBack = callback;
 const registerCommandResponseCallBack = callback => commandResponseCallback = callback;


### PR DESCRIPTION
This PR replaces the commands with more conventional telegram bot slash commands.

I've also added 'followed' and 'reset' commands which list followed blogs and clear all followed blogs respectively.

It is now also possible to follow blogs in DM with the telegram bot.  This allows a user to treat the bot as a kind of rss reader - the bot will DM the user when new posts are published.