### PR TITLE
drop associations with blogs when can no longer write to a chat

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,20 @@ function newPostForBlog( blogPath, postUrl ) {
 			return;
 		}
 
-		chats.forEach( chat => bot.sendMessage( chat.chatId, postUrl ) );
+		chats.forEach(
+			chat => {
+				bot
+					.sendMessage( chat.chatId, postUrl )
+					.catch(
+						error => {
+							if ( error.response && error.response.body && error.response.body.error_code === 403 ) {
+								// we are no longer allowed to write to the telegram chat so clear all associations
+								db.clearFollowedBlogs( chat.chatId );
+							}
+						}
+					);
+			}
+		);
 	} );
 }
 


### PR DESCRIPTION
When a telegram channel or group is deleted or made inaccessible to the bot, we do not handle the error when the bot tries to write to that channel.

This change ensures that we clear all associations with a telegram chat when we are no longer allowed to write to it.